### PR TITLE
Add text and reference to specify use of uppercase keywords

### DIFF
--- a/edit/saml2int/notation.adoc
+++ b/edit/saml2int/notation.adoc
@@ -1,5 +1,7 @@
 == Notation and Terminology
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals, as shown here.
+
 === References to SAML 2.0 specification
 
 When referring to elements from the SAML 2.0 core specification <<SAML2Core>>, the following syntax is used:

--- a/edit/saml2int/notation.adoc
+++ b/edit/saml2int/notation.adoc
@@ -1,6 +1,6 @@
 == Notation and Terminology
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <<RFC2119>> <<RFC8174>> when, and only when, they appear in all capitals, as shown here.
 
 === References to SAML 2.0 specification
 

--- a/edit/saml2int/references.adoc
+++ b/edit/saml2int/references.adoc
@@ -3,6 +3,7 @@
 [bibliography]
 
 - [[[RFC2119]]] IETF RFC 2119, Key words for use in RFCs to Indicate Requirement Levels, March 1997. http://www.ietf.org/rfc/rfc2119.txt
+- [[[RFC8174]]] IETF RFC 8174, Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words, May 2017. http://www.ietf.org/rfc/rfc8174.txt
 - [[[RFC4051]]] IETF RFC 4051, Additional XML Security Uniform Resource Identifiers, April 2005. https://www.ietf.org/rfc/rfc4051.txt
 - [[[SAML2Core]]] OASIS Standard, Assertions and Protocols for the OASIS Security Assertion Markup Language (SAML) V2.0, March 2005. http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
 - [[[SAML2Bind]]] OASIS Standard, Bindings for the OASIS Security Assertion Markup Language (SAML) V2.0, March 2005. http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf


### PR DESCRIPTION
This is a pull request to partially address https://github.com/KantaraInitiative/SAMLprofiles/issues/34. There's currently no reference in the text to RFC2119. Also, RFC2119 has been updated. This pull request intends to add the text and reference