### PR TITLE
Make reference mnemonics consistent with implementation profile document

### DIFF
--- a/edit/saml2int/common_requirements.adoc
+++ b/edit/saml2int/common_requirements.adoc
@@ -32,7 +32,7 @@ IdP and SP deployments MUST support the SAML V2.0 Web Browser SSO Profile, and I
 
 ==== Metadata Consumption and Use
 
-Deployments MUST provision their behavior in the following areas based solely on the consumption of SAML Metadata <<SAML2Meta>> on an automated, periodic or real-time basis using (where applicable) the processing rules defined by the SAML Metadata Interoperability profile <<MetaIOP>>:
+Deployments MUST provision their behavior in the following areas based solely on the consumption of SAML Metadata <<SAML2Meta>> on an automated, periodic or real-time basis using (where applicable) the processing rules defined by the SAML Metadata Interoperability profile <<SAML2MDIOP>>:
 
 * indications of support for Browser SSO and Single Logout profiles
 * selection, determination, and verification of SAML endpoints and bindings
@@ -48,7 +48,7 @@ Consumption of metadata MUST be contingent on verification of a signature (STRON
 
 Metadata without a `validUntil` attribute on its root element MUST be rejected. Metadata whose root element's `validUntil` attribute extends beyond a deployer- or community-imposed threshold MUST be rejected.
 
-_These are critical (but very simple to implement) requirements for secure application of `<<MetaIOP>>` because it is the method by which keys are revoked and the window of revocation is established._
+_These are critical (but very simple to implement) requirements for secure application of `<<SAML2MDIOP>>` because it is the method by which keys are revoked and the window of revocation is established._
 
 ==== Metadata Production
 
@@ -66,7 +66,7 @@ _As an example, deployments that lack support for, or have not tested and integr
 
 Public keys used for signing, encryption, and TLS client and server authentication MUST be expressed via X.509 certificates included in metadata via `<md:KeyDescriptor>` elements.
 
-These certificates SHOULD be long-lived and self-signed. To avoid problems with non-conforming SAML implementations, certificates in metadata SHOULD NOT be expired (though deployments complying with this profile MUST accept expired certificates by virtue of <<MetaIOP>>).
+These certificates SHOULD be long-lived and self-signed. To avoid problems with non-conforming SAML implementations, certificates in metadata SHOULD NOT be expired (though deployments complying with this profile MUST accept expired certificates by virtue of <<SAML2MDIOP>>).
 
 RSA public keys MUST be at least 2048 bits in length. At least 3072 bits is RECOMMENDED for new deployments.
 
@@ -113,7 +113,7 @@ The following default digest algorithm MUST be used in conjunction with the abov
 
 * ```http://www.w3.org/2001/04/xmlenc#sha256``` <<XMLEnc>>
 
-Deployments SHOULD select digest, signature, and encryption algorithms on the basis of the Metadata Profile for Algorithm Support `<<MetaAlg>>`. The above requirements provide acceptable defaults in the absence of any information (as is common) or in the event that these defaults are supported by a peer.
+Deployments SHOULD select digest, signature, and encryption algorithms on the basis of the Metadata Profile for Algorithm Support `<<SAML2MetaAlgSup>>`. The above requirements provide acceptable defaults in the absence of any information (as is common) or in the event that these defaults are supported by a peer.
 
 Deployments MUST NOT use any of the following security-compromised algorithms (even in the presence of the metadata extension indicating a peer supports them):
 

--- a/edit/saml2int/notation.adoc
+++ b/edit/saml2int/notation.adoc
@@ -13,7 +13,7 @@ When referring to elements from the SAML 2.0 metadata specification <<SAML2Meta>
 
 * `<md:MetadataElement>`
 
-When referring to elements from the SAML 2.0 Metadata Extensions for Login and Discovery User Interface specification <<SAML-Metadata-UI-V1.0>>, the following syntax is used:
+When referring to elements from the SAML 2.0 Metadata Extensions for Login and Discovery User Interface specification <<MetaUi>>, the following syntax is used:
 
 * `<mdui:MetadataElement>`
 

--- a/edit/saml2int/references.adoc
+++ b/edit/saml2int/references.adoc
@@ -10,8 +10,8 @@
 - [[[SAML2Prof]]] OASIS Standard, Profiles for the OASIS Security Assertion Markup Language (SAML) V2.0, March 2005. http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf
 - [[[SAML2Meta]]] OASIS Standard, Metadata for the OASIS Security Assertion Markup Language (SAML) V2.0, March 2005. http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf
 - [[[X500SAMLattr]]] OASIS Committee Draft, SAML V2.0 X.500/LDAP Attribute Profile, December 2006. http://docs.oasis-open.org/security/saml/SpecDrafts-Post2.0/sstc-saml-attribute-x500-cd-01.pdf
-- [[[MetaIOP]]] OASIS Committee Specification, SAML V2.0 Metadata Interoperability Profile Version 1.0, August 2009. http://docs.oasis-open.org/security/saml/Post2.0/sstc-metadata-iop.pdf
-- [[[MetaAlg]]] OASIS Committee Specification, SAML V2.0 Metadata Profile for Algorithm Support Version 1.0, February 2011. http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-metadata-algsupport-v1.0-cs01.pdf
+- [[[SAML2MDIOP]]] OASIS Committee Specification, SAML V2.0 Metadata Interoperability Profile Version 1.0, August 2009. http://docs.oasis-open.org/security/saml/Post2.0/sstc-metadata-iop.pdf
+- [[[SAML2MetaAlgSup]]] OASIS Committee Specification, SAML V2.0 Metadata Profile for Algorithm Support Version 1.0, February 2011. http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-metadata-algsupport-v1.0-cs01.pdf
 - [[[IdPDisco]]] OASIS Committee Specification, Identity Provider Discovery Service Protocol and Profile, March 2008. http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-idp-discovery.pdf
 - [[[SAML2Err]]] OASIS Approved Errata, SAML Version 2.0 Errata 05, May 2012. http://docs.oasis-open.org/security/saml/v2.0/sstc-saml-approved-errata-2.0.pdf
 - [[[XMLEnc]]] D. Eastlake et al. XML Encryption Syntax and Processing. World Wide Web Consortium Recommendation, April 2013. https://www.w3.org/TR/xmlenc-core1/
@@ -19,7 +19,7 @@
 - [[[XMLSig]]] D. Eastlake et al. XML-Signature Syntax and Processing, Second Edition. World Wide Web Consortium Recommendation, June 2008. http://www.w3.org/TR/xmldsig-core/
 - [[[SAML2SubjId]]] OASIS Committee Draft, SAMLV2.0 Subject Identifier Attributes Profile Version 1.0, September 2017.  https://www.oasis-open.org/committees/download.php/61575/saml-subject-id-attr-v1.0-wd03.pdf
 - [[[SAML2ASLO]]] OASIS Committee Specification, SAML V2.0 Asynchronous Single Logout Profile Extension Version 1.0, November 2012. http://docs.oasis-open.org/security/saml/Post2.0/saml-async-slo/v1.0/cs01/saml-async-slo-v1.0-cs01.pdf
-- [[[SAML-Metadata-UI-V1.0]]] OASIS Committee Specification, SAML V2.0 Metadata Extensions for Login and Discovery User Interface Version 1.0, 03 April 2012. http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-metadata-ui/v1.0/cs01/sstc-saml-metadata-ui-v1.0-cs01.pdf
+- [[[MetaUi]]] OASIS Committee Specification, SAML V2.0 Metadata Extensions for Login and Discovery User Interface Version 1.0, 03 April 2012. http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-metadata-ui/v1.0/cs01/sstc-saml-metadata-ui-v1.0-cs01.pdf
 - [[[MetaAttr]]] OASIS Committee Specification, SAML V2.0 Metadata Extension for Entity Attributes Version 1.0, August 2009. http://docs.oasis-open.org/security/saml/Post2.0/sstc-metadata-attr-cs-01.pdf
 
 == Non-Normative References

--- a/edit/saml2int/requirements.adoc
+++ b/edit/saml2int/requirements.adoc
@@ -1,6 +1,6 @@
 == Metadata and Trust Management
 
-Identity Providers and Service Providers MUST provide a SAML 2.0 Metadata document representing its entity. How metadata is exchanged is out of scope of this specification. Provided metadata MUST conform to the SAML V2.0 Metadata Interoperability Profile Version 1.0 <<MetaIOP>>.
+Identity Providers and Service Providers MUST provide a SAML 2.0 Metadata document representing its entity. How metadata is exchanged is out of scope of this specification. Provided metadata MUST conform to the SAML V2.0 Metadata Interoperability Profile Version 1.0 <<SAML2MDIOP>>.
 
 Entities SHOULD publish its metadata using the Well-Known Location method defined in <<SAML2Meta>>.
 


### PR DESCRIPTION
Further work on https://github.com/KantaraInitiative/SAMLprofiles/issues/34 to use consistent references across the two documents