### PR TITLE
Add references to <MDUI:UIInfo>, MetaUI

### DIFF
--- a/edit/saml2int/common_requirements.adoc
+++ b/edit/saml2int/common_requirements.adoc
@@ -81,7 +81,7 @@ By virtue of the profile's overall requirements, an IdP's metadata MUST include 
 
 ===== Discovery and User Interface Elements
 
-Metadata MUST include an `<mdui:UIInfo>` element as defined in <<MetaUI>> containing at minimum the sub-elements `<mdui:DisplayName>`, `<mdui:Logo>`, `<mdui:InformationURL>`, and `<mdui:PrivacyStatementURL>`.
+Metadata MUST include an `<mdui:UIInfo>` element as defined in <<MetaUI>> containing at least the child elements `<mdui:DisplayName>`, `<mdui:Logo>`, `<mdui:InformationURL>`, and `<mdui:PrivacyStatementURL>`.
 
 The content of the `<mdui:Logo>` element MUST be either an `https` URL or an in-line image embedded in a `data` URI element.
 

--- a/edit/saml2int/common_requirements.adoc
+++ b/edit/saml2int/common_requirements.adoc
@@ -81,7 +81,7 @@ By virtue of the profile's overall requirements, an IdP's metadata MUST include 
 
 ===== Discovery and User Interface Elements
 
-Metadata MUST include an `<mdui:UIInfo>` element as defined in <<MetaUI>> containing at a minimum the sub-elements `<mdui:DisplayName>`, `<mdui:Logo>`, `<mdui:InformationURL>`, and `<mdui:PrivacyStatementURL>`.
+Metadata MUST include an `<mdui:UIInfo>` element as defined in <<MetaUI>> containing at minimum the sub-elements `<mdui:DisplayName>`, `<mdui:Logo>`, `<mdui:InformationURL>`, and `<mdui:PrivacyStatementURL>`.
 
 The content of the `<mdui:Logo>` element MUST be either an `https` URL or an in-line image embedded in a `data` URI element.
 

--- a/edit/saml2int/common_requirements.adoc
+++ b/edit/saml2int/common_requirements.adoc
@@ -81,7 +81,7 @@ By virtue of the profile's overall requirements, an IdP's metadata MUST include 
 
 ===== Discovery and User Interface Elements
 
-Metadata MUST include the `<mdui:DisplayName>`, `<mdui:Logo>`, `<mdui:InformationURL>`, and `<mdui:PrivacyStatementURL>` elements.
+Metadata MUST include an `<mdui:UIInfo>` element as defined in <<MetaUI>> containing at a minimum the sub-elements `<mdui:DisplayName>`, `<mdui:Logo>`, `<mdui:InformationURL>`, and `<mdui:PrivacyStatementURL>`.
 
 The content of the `<mdui:Logo>` element MUST be either an `https` URL or an in-line image embedded in a `data` URI element.
 


### PR DESCRIPTION
Later SP and IdP specific sections clarify that metadata must contain an <MDUI:UIInfo> element, but the "Discovery and User Interface" section only names sub-elements of the <MDUI:UIInfo> element and does not reference the <<MetaUI>> metadata extension specification.