### PR TITLE
Certs in metadata "shoulds"

### DIFF
--- a/edit/saml2int/common_requirements.adoc
+++ b/edit/saml2int/common_requirements.adoc
@@ -64,12 +64,12 @@ _As an example, deployments that lack support for, or have not tested and integr
 
 [SDP-MD06]:: Public keys used for signing, encryption, and TLS client and server authentication MUST be expressed via X.509 certificates included in metadata via `<md:KeyDescriptor>` elements.
 
-_By virtue of <<SAML2MDIOP>>, this profile (and SAML in general) does not place requierments on the non-key material contained in X.509 certificates in metadata. However, to minimize commmonplace issues with non-conforming SAML implementations, certificates:_
+_By virtue of <<SAML2MDIOP>>, this profile (and SAML in general) does not place requierments on the non-key material contained in X.509 certificates in metadata. However, the following are suggested practices to avoid interoperability issues with deployments outside the scope of this profile:_
 
-* _SHOULD be long-lived_
-* _SHOULD be self-signed_
-* _SHOULD NOT be expired_
-* _SHOULD NOT be signed with MD5- or SHA1-based signature algorithms._
+* _use long-lived certificates_
+* _use self-signed certificates_
+* _do not use expired certificates_
+* _do not sign certificates with MD5- or SHA1-based signature algorithms._
 
 [SDP-MD07]:: RSA public keys MUST be at least 2048 bits in length. At least 3072 bits is RECOMMENDED for new deployments.
 

--- a/edit/saml2int/common_requirements.adoc
+++ b/edit/saml2int/common_requirements.adoc
@@ -64,13 +64,18 @@ _As an example, deployments that lack support for, or have not tested and integr
 
 [SDP-MD06]:: Public keys used for signing, encryption, and TLS client and server authentication MUST be expressed via X.509 certificates included in metadata via `<md:KeyDescriptor>` elements.
 
-These certificates SHOULD be long-lived and self-signed. To avoid problems with non-conforming SAML implementations, certificates in metadata SHOULD NOT be expired (though deployments complying with this profile MUST accept expired certificates by virtue of <<SAML2MDIOP>>).
+_By virtue of <<SAML2MDIOP>>, this profile (and SAML in general) does not place requierments on the non-key material contained in X.509 certificates in metadata. However, to minimize commmonplace issues with non-conforming SAML implementations, certificates:_
+
+* _SHOULD be long-lived_
+* _SHOULD be self-signed_
+* _SHOULD NOT be expired_
+* _SHOULD NOT be signed with MD5- or SHA1-based signature algorithms._
 
 [SDP-MD07]:: RSA public keys MUST be at least 2048 bits in length. At least 3072 bits is RECOMMENDED for new deployments.
 
 [SDP-MD08]:: EC public keys MUST be at least 256 bits in length.
 
-[SDP-MD09]:: Certificates used MUST NOT be signed with an MD5-based signature algorithm and SHOULD NOT be signed with a SHA1-based signature algorithm.
+[SDP-MD09]:: (_REMOVED_)
 
 [SDP-MD10]:: By virtue of the profile's overall requirements, an IdP's metadata MUST include at least one signing certificate (that is, an `<md:KeyDescriptor>` with no `use` attribute or one set to `signing`), and an SP's metadata MUST include at least one encryption certificate (that is, an `<md:KeyDescriptor>` with no `use` attribute or one set to `encryption`).
 


### PR DESCRIPTION
In response to issue #80. 

Created non-normative text to outline SHOULD/SHOULD NOT advice for interop with non-compliant implementations.