### PR TITLE
Various actions from last call.

### DIFF
--- a/edit/saml2int/idp_requirements.adoc
+++ b/edit/saml2int/idp_requirements.adoc
@@ -12,15 +12,19 @@
 
 [SDP-IDP03]:: The endpoint(s) at which an IdP supports receipt of `<samlp:AuthnRequest>` messages MUST be protected by TLS/SSL.
 
-===== Endpoint Verification
-
-[SDP-IDP04]:: When verifying the `AssertionConsumerServiceURL`, it is RECOMMENDED that the IdP perform a case-sensitive string comparison between the requested value and the values found in the SP's metadata. It is OPTIONAL to apply any form of URL canonicalization.
-
 ===== Signing
 
-[SDP-IDP05]:: If a request is signed, IdPs MUST verify the signature or fail the request. An IdP MAY handle a signature verification failure locally rather than via an error response to the SP.
+[SDP-IDP04]:: If a request is signed, IdPs MUST verify the signature or (if the signature is invalid or the IdP is unwilling or unable to attempt validation) fail the request. An IdP MAY handle a signature verification failure locally rather than via an error response to the SP.
 
-[SDP-IDP06]:: IdPs MUST reject unsigned requests in the event that an SP's metadata includes an `AuthnRequestsSigned` attribute set to `true` or `1`.
+[SDP-IDP05]:: IdPs MUST reject unsigned requests in the event that an SP's metadata includes an `AuthnRequestsSigned` attribute set to `true` or `1`.
+
+===== Endpoint Selection/Verification
+
+[SDP-IDP06]:: IdPs MUST verify the `AssertionConsumerServiceURL` supplied in an SP's `<samlp:AuthnRequest>` (if any) against the `<md:AssertionConsumerService>` elements in the SP's metadata. In the absence of such a value, the default endpoint from the SP's metadata MUST be used for the response.
+
+When verifying the `AssertionConsumerServiceURL`, it is RECOMMENDED that the IdP perform a case-sensitive string comparison between the requested value and the values found in the SP's metadata. It is OPTIONAL to apply any form of URL canonicalization.
+
+_The Browser SSO Profile <<SAML2Prof>> notes that validation of the response endpoint is required but does not mandate a specific approach, primarily due to metadata being an optional portion of the original standard. The above is the most common and interoperable approach to meeting this requirement._
 
 ===== Forced Re-Authentication
 

--- a/edit/saml2int/sp_requirements.adoc
+++ b/edit/saml2int/sp_requirements.adoc
@@ -137,7 +137,7 @@ Deep linking also implies support for some form of IdP "discovery", the process 
 
 A common means of discovery is the mapping of resource/application URL (typically virtual host, sometimes path) to a specific IdP. This is strongly discouraged, and is disallowed for collaborative applications, since it makes the sharing of URLs between users from multiple organizations impossible (or at best highly inconvenient).
 
-[SDP-SP24]:: SPs SHOULD consider support for the Identity Provider Discovery Service Protocol and Profile defined in <<IdPDisco>> as it provides a general, composable building block. SPs MAY support other mechanisms and caching solutions (e.g., cookies) as desired, to reduce the frequency of discovery.
+[SDP-SP24]:: SPs SHOULD support the Identity Provider Discovery Service Protocol and Profile defined in <<IdPDisco>> as it provides a general, composable building block. SPs are free to support other mechanisms and caching solutions (e.g., cookies) as desired, to reduce the frequency of discovery.
 
 === Single Logout
 


### PR DESCRIPTION
I reordered the IDP04-IDP06 items for better continuity in addition to the proposed changes. One change I made that is line with how I meant things but was not clear from the wording is that it actually makes it possible for IdPs to simply refuse to attempt signature verification as long as they fail if a request is signed. The rationale is around allowing throttling by IdPs to limit the computational cost if somebody fed in thousands of signed requests.

I decided against adding an SP item for "SP's may sign request" but could be persuaded to do so. The best argument for including it would necessitate explaining that older saml2int explicitly allowed IdPs to ignore signatures.