### PR TITLE
Saml profile name fixes

### DIFF
--- a/edit/saml2int/common_requirements.adoc
+++ b/edit/saml2int/common_requirements.adoc
@@ -30,7 +30,7 @@ _An entityID should be chosen in a manner that minimizes the likelihood of it ch
 
 [SDP-MD01]:: Deployments MUST provision their behavior in the following areas based solely on the consumption of SAML Metadata <<SAML2Meta>> on an automated, periodic or real-time basis using (where applicable) the processing rules defined by the SAML Metadata Interoperability profile <<SAML2MDIOP>>:
 
-* indications of support for Browser SSO and Single Logout profiles
+* indications of support for Web Browser SSO and Single Logout profiles
 * selection, determination, and verification of SAML endpoints and bindings
 * determination of the trustworthiness of XML signing keys and TLS client and server certificates
 * selection of XML Encryption keys

--- a/edit/saml2int/idp_requirements.adoc
+++ b/edit/saml2int/idp_requirements.adoc
@@ -4,7 +4,7 @@ This section provides requirements specific to IdPs, in addition to the Common R
 
 === Web Browser SSO
 
-[SDP-IDP01]:: IdPs MUST support the Browser SSO Profile <<SAML2Prof>>, as updated by the Approved Errata <<SAML2Err>>, with behavior, capabilities, and options consistent with the additional constraints specified in this section.
+[SDP-IDP01]:: IdPs MUST support the Web Browser SSO profile <<SAML2Prof>>, as updated by the Approved Errata <<SAML2Err>>, with behavior, capabilities, and options consistent with the additional constraints specified in this section.
 
 ==== Requests
 
@@ -26,7 +26,7 @@ This section provides requirements specific to IdPs, in addition to the Common R
 
 When verifying the `AssertionConsumerServiceURL`, it is RECOMMENDED that the IdP perform a case-sensitive string comparison between the requested value and the values found in the SP's metadata. It is OPTIONAL to apply any form of URL canonicalization.
 
-_The Browser SSO Profile <<SAML2Prof>> notes that validation of the response endpoint is required but does not mandate a specific approach, primarily due to metadata being an optional portion of the original standard. The above is the most common and interoperable approach to meeting this requirement._
+_The Web Browser SSO profile <<SAML2Prof>> notes that validation of the response endpoint is required but does not mandate a specific approach, primarily due to metadata being an optional portion of the original standard. The above is the most common and interoperable approach to meeting this requirement._
 
 ===== Forced Re-Authentication
 
@@ -88,7 +88,7 @@ _Note that this refers to `<saml:AttributeValue>` elements, not `<saml:Attribute
 
 === Single Logout
 
-[SDP-IDP21]:: IdPs MUST support the Single Logout Profile <<SAML2Prof>>, as updated by the Approved Errata <<SAML2Err>>, with behavior, capabilities, and options consistent with the additional constraints specified in this section.
+[SDP-IDP21]:: IdPs MUST support the Single Logout profile <<SAML2Prof>>, as updated by the Approved Errata <<SAML2Err>>, with behavior, capabilities, and options consistent with the additional constraints specified in this section.
 
 _The term "IdP session" is used to refer to the ongoing state between the IdP and its clients allowing for SSO. Support for logout implies supporting termination of a subject's IdP session in response to receiving a `<samlp:LogoutRequest>` or upon some administrative signal._
 

--- a/edit/saml2int/main.adoc
+++ b/edit/saml2int/main.adoc
@@ -22,7 +22,7 @@ Status:: This document is a Kantara Initiative Group Editors' Draft Document pro
 include::contributors.adoc[]
 
 .Abstract
-This profile specifies behavior and options that deployments of the SAML V2.0 Web Browser SSO Profile <<SAML2Prof>>, and related profiles, are required or permitted to rely on. This deployment profile should not be confused with a SAML implementation profile, such as <<SAML2Impl>>. A deployment profile specifies how software should be configured given a specific set of deployment goals. An implementation profile tells software developers how they must implement their software in order to meet basic requirements.
+This profile specifies behavior and options that deployments of the SAML V2.0 Web Browser SSO profile <<SAML2Prof>>, and related profiles, are required or permitted to rely on. This deployment profile should not be confused with a SAML implementation profile, such as <<SAML2Impl>>. A deployment profile specifies how software should be configured given a specific set of deployment goals. An implementation profile tells software developers how they must implement their software in order to meet basic requirements.
 
 .Copyright Notice
 SAML V2.0 Deployment Profile for Federation Interoperability ©2019 by the respective contributors, used under license.  All rights reserved.

--- a/edit/saml2int/notation.adoc
+++ b/edit/saml2int/notation.adoc
@@ -4,7 +4,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This specification uses the following typographical conventions in text: `<ns:Element>`, `Attribute`, **Datatype**, `OtherCode`. The normative requirements of this specification are individually labeled with a unique identifier in the following form: *[SDP-EXAMPLE01]*. All information within these requirements should be considered normative unless it is set in _italic_ type.  Italicized text is non-normative and is intended to provide additional information that may be helpful in implementing the normative requirements.
 
-The abbreviations IdP and SP are used below to refer to Identity Providers and Service Providers in the sense of their usage within the SAML Browser SSO Profile and Single Logout profiles.
+The abbreviations IdP and SP are used below to refer to Identity Providers and Service Providers in the sense of their usage within the SAML Browser SSO and Single Logout profiles.
 
 Whether explicit or implicit, all the requirements in this document are meant to apply to deployments of SAML profiles and may involve explicit support for requirements by SAML-implementing software and/or supplemental support via application code. Deployments of a Service Provider may refer to both stand-alone implementations of SAML, libraries integrated with an application, or any combination of the two. It is difficult to define a clear boundary between a Service Provider and the application/service it represents, and unnecessary to do so for the purposes of this document.
 

--- a/edit/saml2int/sp_requirements.adoc
+++ b/edit/saml2int/sp_requirements.adoc
@@ -4,7 +4,7 @@ This section provides requirements specific to SPs, in addition to the Common Re
 
 === Web Browser SSO
 
-[SDP-SP01]:: SPs MUST support the Browser SSO Profile <<SAML2Prof>>, as updated by the Approved Errata <<SAML2Err>>, with behavior, capabilities, and options consistent with the additional constraints specified in this section.
+[SDP-SP01]:: SPs MUST support the Web Browser SSO profile <<SAML2Prof>>, as updated by the Approved Errata <<SAML2Err>>, with behavior, capabilities, and options consistent with the additional constraints specified in this section.
 
 ==== Requests
 
@@ -60,7 +60,7 @@ _There are many reasons an SP may be unable or choose not to provide service to 
 
 [SDP-SP13]:: SPs MUST NOT require the presence of a `<saml:NameID>` element.
 
-_Use of `<saml:NameID>` elements in this profile is restricted to their role in the Single Logout Profile, and not for long term identification of subjects. Standardized SAML Attributes are used instead, as described below._
+_Use of `<saml:NameID>` elements in this profile is restricted to their role in the Single Logout profile, and not for long term identification of subjects. Standardized SAML Attributes are used instead, as described below._
 
 ===== Subject Identifiers
 
@@ -129,7 +129,7 @@ _This requirement flows from both the inherent requirements of collaborative app
 
 _It should be possible to request a resource and (authorization permitting) have it supplied as the result of a successful Web Browser SSO profile exchange._
 
-[SDP-SP22]:: It is RECOMMENDED that SPs support the preservation of POST bodies across a successful SSO profile exchange, subject to size limitations dictated by policy or implementation constraints.
+[SDP-SP22]:: It is RECOMMENDED that SPs support the preservation of POST bodies across a successful Web Browser SSO profile exchange, subject to size limitations dictated by policy or implementation constraints.
 
 _Deep linking implies support for SP-initiated SSO, i.e., the direct generation of authentication request messages in response to unauthenticated or insufficiently-authenticated access attempts to an application as a whole, or to specific protected content. Deep linking may co-exist with support for unsolicited responses (so-called IdP-initiated SSO), but precludes its requirement._
 
@@ -143,7 +143,7 @@ A common means of discovery is the mapping of resource/application URL (typicall
 
 === Single Logout
 
-[SDP-SP24]:: SPs MAY support the Single Logout Profile <<SAML2Prof>>, as updated by the Approved Errata <<SAML2Err>>. The following requirements apply in the case of such support.
+[SDP-SP24]:: SPs MAY support the Single Logout profile <<SAML2Prof>>, as updated by the Approved Errata <<SAML2Err>>. The following requirements apply in the case of such support.
 
 ==== Requests
 
@@ -218,7 +218,7 @@ The ability to perform seamless key migration depends upon proper support for co
 * an `<md:ContactPerson>` element with a `contactType` of `technical` and an `<md:EmailAddress>` element
 
 
-If the SP supports the Single Logout Profile, then its metadata MUST contain (within its `<md:SPSSODescriptor>` role element):
+If the SP supports the Single Logout profile, then its metadata MUST contain (within its `<md:SPSSODescriptor>` role element):
 
 * at least one `<md:KeyDescriptor>` element whose `use` attribute is omitted or set to `signing`
 * at least one `<md:SingleLogoutService>` endpoint element (this MAY be omitted if the SP solely issues `<samlp:LogoutRequest>` messages containing the `<aslo:Asynchronous>` extension <<SAML2ASLO>>)


### PR DESCRIPTION
Standardized on names and capitalizations for the primary SAML profiles as:

   Web Browser SSO profile
   Single Logout profile

Most importantly, I standardized and spelled out all instances that referred to the Web Browser SSO profile (which was referred to in our doc as "Web Browser SSO profile", "Browser SSO profile" and in one case "SSO profile".)


For capitalization, I chose to leave the profile name itself capitalized (title case), but to treat the word "profile" as being non-capitalized. Arguably that breaks some formal grammar rules, but it seems to most correctly match the OASIS precedent and made it more natural to say "the Web Browser SSO and Single Logout profiles" in a couple of places. 

Ironically, there is inconsistency in the OASIS SAML Profiles document itself . Excluding section headers (which are all in full title case), that document has one instance each of "web browser SSO profile", "Web Browser SSO profile" and "Single Logout profile". 

